### PR TITLE
搜索功能优化

### DIFF
--- a/src/components/Layout/components/LayoutHeaderSearch.vue
+++ b/src/components/Layout/components/LayoutHeaderSearch.vue
@@ -56,7 +56,7 @@ const { state: suggestResult, isLoading: suggestLoading, execute } = useAsyncSta
       result.songs, ['name', 'formatAuthor', 'alias'], mainStore.searchKeyword, primaryColor
     );
     res.data.result.playlists = markSearchKeyword(
-      result.playlists, ['name'], mainStore.searchKeyword, primaryColor
+      result.playlists || [], ['name'], mainStore.searchKeyword, primaryColor
     );
     return res.data.result;
   }), {}, { resetOnExecute: false, immediate: false }
@@ -296,7 +296,7 @@ onUnmounted(() => {
                   <span> - </span>
                   <span v-html="item.formatAuthorRichText" />
                 </div>
-                <p v-show="!suggestLoading && suggestResult.playlists" class="flex items-center pl-4 text-base opacity-50">
+                <p v-show="!suggestLoading && suggestResult.playlists?.length > 0" class="flex items-center pl-4 text-base opacity-50">
                   <n-icon :component="List" />
                   <span class="ml-2">歌单</span>
                 </p>


### PR DESCRIPTION
问题: 当在搜索框输入"雅俗"时, 搜索结果为空; 输入"雅"时才出现单曲和歌单的结果
原因: 输入"雅俗"时由于没有对应的歌单, 所以单曲和歌单都不显示了, 但实际上是有单曲的
建议: 即使没有"歌单", 搜索结果也应显示"单曲", 提高体验~